### PR TITLE
Remove unneeded violations filter

### DIFF
--- a/procedures_js/alert_scheduler.js
+++ b/procedures_js/alert_scheduler.js
@@ -75,7 +75,6 @@ function get_first_regex_group(regex, s) {
 
 return {
   scheduled: exec(FIND_VIEWS)
-    .filter((v) => ((find_tags(`$${v.qualified_view_name}`, 'VIOLATION_SCHEDULE')[0] == null) && !v.qualified_view_name.contains('VIOLATION_QUERY')))
     .map((v) => ({
       ...v,
       view_definition: get_ddl(v.qualified_view_name),


### PR DESCRIPTION
The removed violation filter in the alert scheduler checked if a query was not a violation query. This filter is not needed anymore as the schedule is now placed in the `meta` section instead of the query body of the violation. 