### PR TITLE
Add custom Jira formatting to ef-jira

### DIFF
--- a/ef_jira.tf
+++ b/ef_jira.tf
@@ -117,6 +117,11 @@ resource "snowflake_function" "jira_handler" {
         local.data_schema,
         snowflake_function.json_beautify_with_indent.name,
       ])
+      object_assign_function = join(".", [
+        local.snowalert_database_name,
+        local.data_schema,
+        snowflake_function.object_assign.name,
+      ])
     }
   )
 

--- a/handler_functions_sql/jira_handler_v3.sql
+++ b/handler_functions_sql/jira_handler_v3.sql
@@ -3,300 +3,304 @@ ${jira_api_function}(
     '/rest/api/3/issue',
     TO_JSON(
         OBJECT_CONSTRUCT(
-            'fields', OBJECT_CONSTRUCT(
-                'labels', ARRAY_CONSTRUCT('SnowAlert'),
-                'assignee', OBJECT_CONSTRUCT(
-                    'accountId',  COALESCE(payload['assignee'], NULL)
-                ),
-                'project', OBJECT_CONSTRUCT(
-                    'key', COALESCE(payload['project'], '${default_jira_project}')
-                ),
-                'issuetype', OBJECT_CONSTRUCT(
-                    'name', COALESCE(payload['issue_type'], '${default_jira_issue_type}')
-                ),
-                'summary', alert['TITLE']::STRING,
-                'description', OBJECT_CONSTRUCT(
-                    'version', 1,
-                    'type', 'doc',
-                    'content', ARRAY_CONSTRUCT(
-                        OBJECT_CONSTRUCT(
-                            'type', 'paragraph',
-                            'content', ARRAY_CONSTRUCT(
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Alert ID: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+            'fields', ${object_assign_function}(OBJECT_CONSTRUCT
+                (
+
+                    'labels', ARRAY_CONSTRUCT('SnowAlert'),
+                    'assignee', OBJECT_CONSTRUCT(
+                        'accountId',  COALESCE(payload['assignee'], NULL)
+                    ),
+                    'project', OBJECT_CONSTRUCT(
+                        'key', COALESCE(payload['project'], '${default_jira_project}')
+                    ),
+                    'issuetype', OBJECT_CONSTRUCT(
+                        'name', COALESCE(payload['issue_type'], '${default_jira_issue_type}')
+                    ),
+                    'summary', alert['TITLE']::STRING,
+                    'description', OBJECT_CONSTRUCT(
+                        'version', 1,
+                        'type', 'doc',
+                        'content', ARRAY_CONSTRUCT(
+                            OBJECT_CONSTRUCT(
+                                'type', 'paragraph',
+                                'content', ARRAY_CONSTRUCT(
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Alert ID: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['ID']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Query ID: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['ID']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Query ID: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['QUERY_ID']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Query Name: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['QUERY_ID']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Query Name: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['QUERY_NAME']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Environment: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['QUERY_NAME']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Environment: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['ENVIRONMENT']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Sources: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['ENVIRONMENT']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Sources: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['SOURCES']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Categories: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['SOURCES']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Categories: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', COALESCE(alert['CATEGORIES']::STRING, '-')
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Actor: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', COALESCE(alert['CATEGORIES']::STRING, '-')
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Actor: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['ACTOR']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Object: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['ACTOR']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Object: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['OBJECT']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Action: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['OBJECT']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Action: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['ACTION']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Title: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['ACTION']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Title: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['TITLE']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Event Time: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['TITLE']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Event Time: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['EVENT_TIME']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Alert Time: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['EVENT_TIME']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Alert Time: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['ALERT_TIME']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Detector: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['ALERT_TIME']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Detector: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['DETECTOR']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Severity: ',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['DETECTOR']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Severity: ',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
-                                    )
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['SEVERITY']::STRING
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'hardBreak'
-                                ),
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Description:',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
-                                        )
-                                    )
-                                )
-                            )
-                        ),
-                        OBJECT_CONSTRUCT(
-                            'type', 'blockquote',
-                            'content', ARRAY_CONSTRUCT(
-                                OBJECT_CONSTRUCT(
-                                    'type', 'paragraph',
-                                    'content', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'text',
-                                            'text', alert['DESCRIPTION']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', alert['SEVERITY']::STRING
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'hardBreak'
+                                    ),
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Description:',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
                                         )
                                     )
                                 )
-                            )
-                        ),
-                        OBJECT_CONSTRUCT(
-                            'type', 'paragraph',
-                            'content', ARRAY_CONSTRUCT(
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', 'Event Data:',
-                                    'marks', ARRAY_CONSTRUCT(
-                                        OBJECT_CONSTRUCT(
-                                            'type', 'strong'
+                            ),
+                            OBJECT_CONSTRUCT(
+                                'type', 'blockquote',
+                                'content', ARRAY_CONSTRUCT(
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'paragraph',
+                                        'content', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'text',
+                                                'text', alert['DESCRIPTION']::STRING
+                                            )
                                         )
                                     )
                                 )
-                            )
-                        ),
-                        OBJECT_CONSTRUCT(
-                            'type', 'codeBlock',
-                            'attrs', OBJECT_CONSTRUCT(),
-                            'content', ARRAY_CONSTRUCT(
-                                OBJECT_CONSTRUCT(
-                                    'type', 'text',
-                                    'text', alert['EVENT_DATA']::STRING
+                            ),
+                            OBJECT_CONSTRUCT(
+                                'type', 'paragraph',
+                                'content', ARRAY_CONSTRUCT(
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', 'Event Data:',
+                                        'marks', ARRAY_CONSTRUCT(
+                                            OBJECT_CONSTRUCT(
+                                                'type', 'strong'
+                                            )
+                                        )
+                                    )
+                                )
+                            ),
+                            OBJECT_CONSTRUCT(
+                                'type', 'codeBlock',
+                                'attrs', OBJECT_CONSTRUCT(),
+                                'content', ARRAY_CONSTRUCT(
+                                    OBJECT_CONSTRUCT(
+                                        'type', 'text',
+                                        'text', ${json_beautify_function}(alert['EVENT_DATA']::STRING, 2)
+                                    )
                                 )
                             )
                         )
                     )
-                )
+                ),
+            payload['fields']
             )
         )
     ),


### PR DESCRIPTION
This PR adds support to add custom formatting while creating Jira-based alerts. 

The formatting can be provided in the `fields` fields of the payload, where the structure provided there would override the structure of the standard SnowAlert ticket.

Example alert:

```

create or replace view SNOWALERT.RULES.JIRA_TEST_VIEW(
	ENVIRONMENT,
	ACTOR,
	SOURCES,
	ACTION,
	OBJECT,
	TITLE,
	EVENT_TIME,
	ALERT_TIME,
	DESCRIPTION,
	DETECTOR,
	EVENT_DATA,
	SEVERITY,
	QUERY_ID,
	SCHEDULE,
	LOOKBACK,
	HANDLERS
) as
SELECT 'dev' AS environment
  , 'oz' AS actor
  , ARRAY_CONSTRUCT('jira snowalert test') AS sources
  , 'Bye' AS action
  , 'Jira test' AS object
  , 'jira snowalert test' AS title
  , current_timestamp() AS event_time
  , CURRENT_TIMESTAMP() AS alert_time
  , 'snowalert terraform oz test' AS description
  , 'SnowAlert' AS detector
  , OBJECT_CONSTRUCT(*) AS event_data
  , 'medium' AS severity
  , '1234xyz' AS query_id
  , 'USING CRON * * * * * UTC' AS schedule
  , '1d' AS lookback
  , OBJECT_CONSTRUCT('type', 'ef-jira', 'project', 'SAD', 'issue_type', 'Story', 'fields', 
  
    OBJECT_CONSTRUCT( 'description', OBJECT_CONSTRUCT(
                    'version', 1,
                    'type', 'doc',
                    'content', ARRAY_CONSTRUCT(
                        OBJECT_CONSTRUCT(
                            'type', 'paragraph',
                            'content', ARRAY_CONSTRUCT(
                                OBJECT_CONSTRUCT(
                                    'type', 'text',
                                    'text', 'Overridden Description'
                                )
                            )
                        )
                    )
                )
              )
         ) AS handlers
FROM (
        SELECT 
              2 
        WHERE 
             1 = 1
);
```

