### PR TITLE
Don't suspend SA tasks on failures

### DIFF
--- a/tasks.tf
+++ b/tasks.tf
@@ -10,6 +10,8 @@ resource "snowflake_task" "snowalert_alerts_merge_task" {
   sql_statement = "CALL ${local.results_schema}.${snowflake_procedure.alerts_merge.name}('30m')"
   enabled       = true
 
+  suspend_task_after_num_failures = 0
+
   depends_on = [
     module.snowalert_grants
   ]
@@ -26,6 +28,8 @@ resource "snowflake_task" "snowalert_suppression_merge_task" {
   after         = [snowflake_task.snowalert_alerts_merge_task.name]
   sql_statement = "CALL ${local.snowalert_database_name}.${local.results_schema}.${snowflake_procedure.alert_suppressions_runner_without_queries_like.name}()"
   enabled       = true
+
+  suspend_task_after_num_failures = 0
 
   depends_on = [
     module.snowalert_grants
@@ -45,6 +49,8 @@ resource "snowflake_task" "alert_processor_task" {
   sql_statement = "CALL ${local.results_schema}.${snowflake_procedure.alert_processor_with_default_correlation_period.name}()"
   enabled       = true
 
+  suspend_task_after_num_failures = 0
+
   depends_on = [
     module.snowalert_grants
   ]
@@ -63,6 +69,8 @@ resource "snowflake_task" "alert_dispatcher_task" {
   sql_statement = "CALL ${local.results_schema}.${snowflake_procedure.alert_dispatcher.name}()"
   enabled       = true
 
+  suspend_task_after_num_failures = 0
+
   depends_on = [
     module.snowalert_grants
   ]
@@ -80,6 +88,8 @@ resource "snowflake_task" "alert_scheduler_task" {
   sql_statement = "CALL ${local.results_schema}.${snowflake_procedure.alert_scheduler.name}('${local.snowalert_warehouse_name}')"
   enabled       = true
 
+  suspend_task_after_num_failures = 0
+
   depends_on = [
     module.snowalert_grants
   ]
@@ -92,6 +102,8 @@ resource "snowflake_task" "violation_scheduler_task" {
   database  = local.snowalert_database_name
   schema    = local.results_schema
   name      = "VIOLATION_SCHEDULER"
+
+  suspend_task_after_num_failures = 0
 
   schedule      = "USING CRON ${var.violation_scheduler_schedule} UTC"
   sql_statement = "CALL ${local.results_schema}.${snowflake_procedure.violation_scheduler.name}('${local.snowalert_warehouse_name}')"


### PR DESCRIPTION
We should not auto-suspend these tasks when there are intermittent errors (e.g. warehouse overload), we want to resume without having to manually un-suspend the tasks.