### PR TITLE
Set SUSPEND_TASK_AFTER_NUM_FAILURES parameter to zero on results schema.

### DIFF
--- a/schemas.tf
+++ b/schemas.tf
@@ -39,7 +39,6 @@ resource "snowflake_schema" "results" {
 }
 
 resource "snowflake_object_parameter" "results_schema_suspend_task_after_num_failures" {
-  count    = var.create_schemas == true ? 1 : 0
   provider = snowflake.admin_role
 
   key         = "SUSPEND_TASK_AFTER_NUM_FAILURES"

--- a/schemas.tf
+++ b/schemas.tf
@@ -38,6 +38,20 @@ resource "snowflake_schema" "results" {
   name     = local.results_schema_name
 }
 
+resource "snowflake_object_parameter" "results_schema_suspend_task_after_num_failures" {
+  count    = var.create_schemas == true ? 1 : 0
+  provider = snowflake.admin_role
+
+  key         = "SUSPEND_TASK_AFTER_NUM_FAILURES"
+  value       = "0"
+  object_type = "SCHEMA"
+
+  object_identifier {
+    database = local.snowalert_database_name
+    name     = local.results_schema
+  }
+}
+
 locals {
   results_schema = var.create_schemas == true ? snowflake_schema.results[0].name : local.results_schema_name
 }


### PR DESCRIPTION
The SUSPEND_TASK_AFTER_NUM_FAILURES = 0 is to disable task auto suspension on multiple time of failures.  With this parameter set, tasks in the results schema will not be suspended after consecutive failure.