### PR TITLE
Suspend alert_processor task

### DIFF
--- a/tasks.tf
+++ b/tasks.tf
@@ -43,7 +43,7 @@ resource "snowflake_task" "alert_processor_task" {
 
   after         = [snowflake_task.snowalert_suppression_merge_task.name]
   sql_statement = "CALL ${local.results_schema}.${snowflake_procedure.alert_processor_with_default_correlation_period.name}()"
-  enabled       = true
+  enabled       = false
 
   depends_on = [
     module.snowalert_grants


### PR DESCRIPTION
let's pause this until we can expand the defensive design of the values passed in the `actor`, `action`, and `object` fields to support arrays and objects [here](https://github.com/Snowflake-Labs/terraform-snowflake-snowalert/blob/main/procedures_js/alert_processor.js#L61-L68) as those have been causing errors in production