### PR TITLE
Add support for sovereign cloud.

### DIFF
--- a/ef_smtp.tf
+++ b/ef_smtp.tf
@@ -51,7 +51,7 @@ resource "snowflake_external_function" "smtp_send" {
   return_null_allowed       = true
   max_batch_rows            = 1
   api_integration           = module.geff_snowalert[0].api_integration_name
-  url_of_proxy_and_resource = "${module.geff_snowalert[0].api_gateway_invoke_url}${var.env}/https"
+  url_of_proxy_and_resource = "${module.geff_snowalert[0].api_gateway_invoke_url}${var.env}/smtp"
 
   return_type     = "VARIANT"
   return_behavior = "VOLATILE"

--- a/functions.tf
+++ b/functions.tf
@@ -242,6 +242,10 @@ resource "snowflake_function_grant" "urlencode" {
     var.ingest_role,
     var.modeling_role,
   ]
+
+  depends_on = [
+    snowflake_function.urlencode,
+  ]
 }
 
 resource "snowflake_function" "array_set" {

--- a/geff.tf
+++ b/geff.tf
@@ -1,7 +1,7 @@
 module "geff_snowalert" {
   count  = length(var.handlers) > 0 ? 1 : 0
   source = "Snowflake-Labs/api-integration-with-geff-aws/snowflake"
-  version = "0.3.6"
+  version = "0.3.7"
 
   # Required
   prefix = var.prefix
@@ -12,7 +12,6 @@ module "geff_snowalert" {
 
   # AWS
   aws_region = local.aws_region
-  arn_format = var.arn_format
 
   # Other config items
   geff_image_version = var.geff_image_version
@@ -22,6 +21,7 @@ module "geff_snowalert" {
   providers = {
     snowflake.api_integration_role     = snowflake.api_integration_role
     snowflake.storage_integration_role = snowflake.storage_integration_role
+    snowsql.storage_integration_role   = snowsql.storage_integration_role
     aws                                = aws
   }
 }

--- a/grants.tf
+++ b/grants.tf
@@ -1,5 +1,5 @@
 module "snowalert_grants" {
-  source = "git@github.com:Snowflake-Labs/terraform-snowflake-snowalert-rbac.git?ref=v0.2.5"
+  source = "git::https://github.com/Snowflake-Labs/terraform-snowflake-snowalert-rbac.git?ref=v0.2.5"
 
   snowalert_warehouse_name = var.snowalert_warehouse_name
   snowalert_database_name  = var.snowalert_database_name

--- a/schemas.tf
+++ b/schemas.tf
@@ -24,6 +24,8 @@ resource "snowflake_schema" "rules" {
 
   database = local.snowalert_database_name
   name     = local.rules_schema_name
+
+  is_managed = var.use_managed_schema
 }
 
 locals {
@@ -36,6 +38,8 @@ resource "snowflake_schema" "results" {
 
   database = local.snowalert_database_name
   name     = local.results_schema_name
+
+  is_managed = var.use_managed_schema
 }
 
 resource "snowflake_object_parameter" "results_schema_suspend_task_after_num_failures" {
@@ -61,6 +65,8 @@ resource "snowflake_schema" "monitoring" {
 
   database = local.snowalert_database_name
   name     = local.monitoring_schema_name
+
+  is_managed = var.use_managed_schema
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,12 @@ variable "create_schemas" {
   description = "Flag to create schemas within the module or not."
 }
 
+variable "use_managed_schema" {
+  type        = bool
+  default     = true
+  description = "Flag to create schemas within the module or not."
+}
+
 variable "create_tables" {
   type        = bool
   default     = false
@@ -256,12 +262,6 @@ variable "warehouse_external_roles" {
   default     = []
 }
 
-variable "arn_format" {
-  type        = string
-  description = "ARN format could be aws or aws-us-gov. Defaults to non-gov."
-  default     = "aws"
-}
-
 variable "jira_api_version" {
   type        = string
   description = "Version of the JIRA API to use"
@@ -287,9 +287,7 @@ data "aws_partition" "current" {}
 locals {
   account_id = data.aws_caller_identity.current.account_id
   aws_region = data.aws_region.current.name
-}
 
-locals {
   snowalert_secret_arns = flatten([
     contains(var.handlers, "jira") == true ? [var.jira_secrets_arn] : [],
     contains(var.handlers, "slack") == true ? [var.slack_secrets_arn] : [],

--- a/versions.tf
+++ b/versions.tf
@@ -4,18 +4,27 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38.0"
+      version = ">= 5.72.0"
     }
 
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = ">= 0.62.0"
+      version = ">= 0.73.0"
 
       configuration_aliases = [
         snowflake.api_integration_role,
         snowflake.storage_integration_role,
         snowflake.admin_role,
         snowflake.alerting_role,
+      ]
+    }
+
+    snowsql = {
+      source  = "aidanmelen/snowsql"
+      version = ">= 1.3.3"
+
+      configuration_aliases = [
+        snowsql.storage_integration_role,
       ]
     }
   }


### PR DESCRIPTION
Add support for sovereign cloud ARN format. Also, use the snowsql Terraform provider if needed when the official Snowflake Terraform provider does not support storage integration on a specific sovereign cloud yet.  Fix smtp handler GEFF url typo.